### PR TITLE
Corrected user plugins location

### DIFF
--- a/Plugins.cpp
+++ b/Plugins.cpp
@@ -64,8 +64,8 @@ Plugins::Plugins(QObject *p) : QObject(p) {
 	else
 		qsSystemPlugins = QLatin1String("Plugins");
 	// User plugins directory
-	QString appDataLocation = QStandardPaths::writableLocation(QStandardPaths::HomeLocation);
-	qsUserPlugins = appDataLocation + QLatin1String("/AppData/Roaming/Mumble/Plugins");
+	QString appDataLocation = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+	qsUserPlugins = appDataLocation + QLatin1String("/Plugins");
 
 	QTimer *timer=new QTimer(this);
 	timer->setObjectName(QLatin1String("Timer"));

--- a/main.cpp
+++ b/main.cpp
@@ -33,6 +33,7 @@
 
 int main(int argc, char *argv[])
 {
+    QCoreApplication::setApplicationName("Mumble");
     QApplication a(argc, argv);
     MumblePAHelper w;
     w.show();

--- a/mumblepahelper.cpp
+++ b/mumblepahelper.cpp
@@ -87,6 +87,32 @@ void MumblePAHelper::on_plugins_ContextChanged(const QString context) {
 
 void MumblePAHelper::on_plugins_LinkLost(const PluginInfo *pi) {
     QMainWindow::statusBar()->showMessage(tr("Lost link to plugin %1").arg(pi->shortname));
+
+	// Reset avatar posititon
+	qdsbAPX->setValue(0);
+	qdsbAPY->setValue(0);
+	qdsbAPZ->setValue(0);
+
+	qdsbAFX->setValue(0);
+	qdsbAFY->setValue(0);
+	qdsbAFZ->setValue(0);
+
+	qdsbATX->setValue(0);
+	qdsbATY->setValue(0);
+	qdsbATZ->setValue(0);
+
+	// Reset camera position
+	qdsbCPX->setValue(0);
+	qdsbCPY->setValue(0);
+	qdsbCPZ->setValue(0);
+
+	qdsbCFX->setValue(0);
+	qdsbCFY->setValue(0);
+	qdsbCFZ->setValue(0);
+
+	qdsbCTX->setValue(0);
+	qdsbCTY->setValue(0);
+	qdsbCTZ->setValue(0);
 }
 
 void MumblePAHelper::on_plugins_Linked(const PluginInfo *pi) {


### PR DESCRIPTION
- Corrected user plugins location path: now it uses the right Qt
  StandardPath, this means that it works also on other platforms.
- The values are now set to 0 when the the link to the plugin is lost.
