### PR TITLE
Fix cross-compilation with MinGW on Linux

### DIFF
--- a/Plugins.h
+++ b/Plugins.h
@@ -37,7 +37,7 @@
 
 #ifdef Q_OS_WIN
 #include <windows.h>
-#include <Tlhelp32.h>
+#include <tlhelp32.h>
 #endif
 
 #include "../mumble/plugins/mumble_plugin.h"


### PR DESCRIPTION
The correct header name is **tlhelp32.h** and not **Tlhelp32.h**.
This is a problem when cross-compiling on Linux, since it is case-sensitive.