### PR TITLE
Fix static build with MinGW on Linux

### DIFF
--- a/MumblePAHelper.pro
+++ b/MumblePAHelper.pro
@@ -9,6 +9,11 @@ QT       += core gui widgets
 TARGET = MumblePAHelper
 TEMPLATE = app
 
+win32-g++:CONFIG(static) {
+  DEFINES += MINGW_STATIC_BUILD
+  LIBS += -lqwindows -lQt5PlatformSupport
+}
+
 SOURCES += main.cpp\
         mumblepahelper.cpp \
     Plugins.cpp

--- a/main.cpp
+++ b/main.cpp
@@ -28,6 +28,11 @@
    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+#ifdef MINGW_STATIC_BUILD
+#include <QtPlugin>
+Q_IMPORT_PLUGIN (QWindowsIntegrationPlugin)
+#endif
+
 #include <QApplication>
 #include "mumblepahelper.h"
 


### PR DESCRIPTION
The static MinGW Qt 5 available in Fedora's repositories doesn't import the QWindows plugin automatically. This results in Windows being unable to start the program, since the plugin is missing.
The solution is to add the required libraries in the project file and manually import the QWindows plugin in main.cpp.

![qwindows](https://cloud.githubusercontent.com/assets/5897523/22177450/01d3c38a-e01e-11e6-978f-bc8c40969044.png)