### PR TITLE
Fix static build for latest MXE's Qt package

### DIFF
--- a/MumblePAHelper.pro
+++ b/MumblePAHelper.pro
@@ -9,9 +9,10 @@ QT       += core gui widgets
 TARGET = MumblePAHelper
 TEMPLATE = app
 
-win32-g++:CONFIG(static) {
-  DEFINES += MINGW_STATIC_BUILD
-  LIBS += -lqwindows -lQt5PlatformSupport
+win32 {
+  isEqual(QT_MAJOR_VERSION, 5) {
+    QTPLUGIN += qwindows
+  }
 }
 
 SOURCES += main.cpp\

--- a/main.cpp
+++ b/main.cpp
@@ -28,11 +28,6 @@
    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#ifdef MINGW_STATIC_BUILD
-#include <QtPlugin>
-Q_IMPORT_PLUGIN (QWindowsIntegrationPlugin)
-#endif
-
 #include <QApplication>
 #include "mumblepahelper.h"
 


### PR DESCRIPTION
The "Qt5PlatformSupport" library isn't available anymore in latest MXE's Qt package.
This commit removes the bad workaround previously implemented for the static build with Fedora's MinGW packages and, instead, adds "qwindows" to the list of Qt plugins to import.