### PR TITLE
Fix Plugin path on Linux

### DIFF
--- a/Plugins.cpp
+++ b/Plugins.cpp
@@ -66,7 +66,7 @@ Plugins::Plugins(QObject *p)
 #if defined(Q_OS_WIN)
 	qsUserPlugins = homeLocation + QLatin1String("/AppData/Roaming/Mumble/Plugins");
 #else
-	qsUserPlugins = homeLocation + QLatin1String("/.local/share/Mumble/Mumble/plugins");
+	qsUserPlugins = homeLocation + QLatin1String("/.local/share/Mumble/Mumble/Plugins");
 #endif
 
 	QTimer *timer=new QTimer(this);

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ User directory: **%AppData%\Roaming\Mumble\Plugins**
 ### Linux
 System directory: **/usr/lib/mumble**
 
-User directory: **~/.local/share/Mumble/Plugins**
+User directory: **~/.local/share/Mumble/Mumble/Plugins**
 ___
 Mumble installs the plugins in the system directory and downloads the updated ones in the user
 directory.


### PR DESCRIPTION
The official user plugin path for Mumble is `~/.local/share/Mumble/Mumble/Plugins`, so it makes sense to use the same one here.